### PR TITLE
Add sbt-coursier to project/plugins.sbt - fixes Console SBT/IntelliJ fighting for ivy lock files.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")


### PR DESCRIPTION
Statically, probably an insignificant speed up (~~ 5 seconds for a complete `clean update compile` compared to vanilla SBT), but coursier fixes my console & IntelliJ fighting for lock files.

```
[info] Compiling 9 Scala sources to /Users/eric/Work/ta-catalog/logging/target/scala-2.12/classes ...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Run 'evicted' to see detailed eviction warnings
Waiting for lock on /Users/eric/.ivy2/.sbt.ivy.lock to be available...
[info] Updating tecrmi...
[info] Updating common...
[info] Updating form...
[info] Compiling 1 Scala source to /Users/eric/Work/ta-catalog/translations/target/scala-2.12/classes ...
Waiting for lock on /Users/eric/.ivy2/.sbt.ivy.lock to be available...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Run 'evicted' to see detailed eviction warnings
[info] Done updating.
Waiting for lock on /Users/eric/.ivy2/.sbt.ivy.lock to be available...
[warn] There may be incompatibilities among your library dependencies.
[warn] Run 'evicted' to see detailed eviction warnings
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Run 'evicted' to see detailed eviction warnings
Waiting for lock on /Users/eric/.ivy2/.sbt.ivy.lock to be available...
[info] Updating orig...
[info] Done compiling.
```

I also run into this issue a lot when I have multiple IDEA-windows open when playing with `-SNAPSHOTS`
